### PR TITLE
Ensure that keywords aren't used for variable names

### DIFF
--- a/src/main/java/il/ac/technion/cs/fling/internal/grammar/types/ClassParameter.java
+++ b/src/main/java/il/ac/technion/cs/fling/internal/grammar/types/ClassParameter.java
@@ -1,6 +1,8 @@
 package il.ac.technion.cs.fling.internal.grammar.types;
+
+import static il.ac.technion.cs.fling.namers.NaiveNamer.lowerCamelCase;
+import static il.ac.technion.cs.fling.namers.NaiveNamer.unreservedName;
 import static java.util.Objects.requireNonNull;
-import il.ac.technion.cs.fling.namers.NaiveNamer;
 // TODO allow primitive types.
 public class ClassParameter implements StringTypeParameter {
   public final Class<?> parameterClass;
@@ -11,7 +13,9 @@ public class ClassParameter implements StringTypeParameter {
     return parameterClass.getCanonicalName();
   }
   @Override public String baseParameterName() {
-    return unPrimitiveTypeSimple(NaiveNamer.lowerCamelCase(parameterClass.getSimpleName()));
+    if (parameterClass.isPrimitive())
+      return parameterClass.getSimpleName().substring(0, 1);
+    return unreservedName(lowerCamelCase(parameterClass.getSimpleName()));
   }
   @Override public int hashCode() {
     return parameterClass.hashCode();
@@ -37,18 +41,6 @@ public class ClassParameter implements StringTypeParameter {
                             boolean.class.getName().equals(typeName) ? Boolean.class.getCanonicalName() : //
                                 char.class.getName().equals(typeName) ? Character.class.getCanonicalName() : //
                                     void.class.getName().equals(typeName) ? Void.class.getCanonicalName() : //
-                                        typeName;
-  }
-  public static String unPrimitiveTypeSimple(final String typeName) {
-    return byte.class.getName().equals(typeName) ? "b" : //
-        short.class.getName().equals(typeName) ? "s" : //
-            int.class.getName().equals(typeName) ? "i" : //
-                long.class.getName().equals(typeName) ? "l" : //
-                    float.class.getName().equals(typeName) ? "f" : //
-                        double.class.getName().equals(typeName) ? "d" : //
-                            boolean.class.getName().equals(typeName) ? "b" : //
-                                char.class.getName().equals(typeName) ? "c" : //
-                                    void.class.getName().equals(typeName) ? "v" : //
                                         typeName;
   }
 }

--- a/src/main/java/il/ac/technion/cs/fling/namers/NaiveNamer.java
+++ b/src/main/java/il/ac/technion/cs/fling/namers/NaiveNamer.java
@@ -23,6 +23,9 @@ import il.ac.technion.cs.fling.internal.compiler.ast.nodes.FieldNode.FieldNodeFr
 import il.ac.technion.cs.fling.internal.grammar.rules.Component;
 import il.ac.technion.cs.fling.internal.grammar.rules.Constants;
 import il.ac.technion.cs.fling.internal.grammar.rules.Variable;
+
+import javax.lang.model.SourceVersion;
+
 public class NaiveNamer implements Namer {
   private final Map<Variable, Integer> astChildrenCounter = new HashMap<>();
   private final Map<Component, Integer> notationsChildrenCounter = new HashMap<>();
@@ -167,6 +170,11 @@ public class NaiveNamer implements Namer {
     }
     final int position = usedNames.put(baseName, usedNames.get(baseName) + 1);
     return baseName + position;
+  }
+  public static String unreservedName(final String name) {
+    if (!SourceVersion.isKeyword(name))
+      return name;
+    return unreservedName(name + "_");
   }
   @Override public String headVariableClassName(final Variable variable) {
     return variable.name();


### PR DESCRIPTION
This corrects the generation of variable names corresponding to terminal parameters, such as Class or Enum.
Previous implementation could erronously generate code such as: `java.lang.Enum enum = ...;` or `Type method(Class class)`